### PR TITLE
replace run-shell-command

### DIFF
--- a/cl-prada/planner.lisp
+++ b/cl-prada/planner.lisp
@@ -54,4 +54,4 @@ SST_branch 3
     (let ((domain (get-domain domain-name)))
       (write-prada-files domain reward-list)
       (with-output-to-string (asdf::*verbose-out*)
-        (asdf:run-shell-command "cd /tmp; ~a" (planner-path))))))
+        (uiop:run-program (format nil "cd /tmp; ~a" (planner-path)))))))


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```